### PR TITLE
feat: 로그인과 회원가입에 AWS Cognito 적용

### DIFF
--- a/env.d.ts
+++ b/env.d.ts
@@ -1,0 +1,6 @@
+declare namespace NodeJS {
+  interface ProcessEnv {
+    NEXT_PUBLIC_COGNITO_USER_POOL_ID: string;
+    NEXT_PUBLIC_COGNITO_CLIENT_ID: string;
+  }
+}

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "@emotion/styled": "^11.11.0",
     "@hookform/resolvers": "^3.3.4",
     "@tanstack/react-query": "^5.17.12",
+    "amazon-cognito-identity-js": "^6.3.7",
     "axios": "^1.6.5",
     "framer-motion": "^10.18.0",
     "next": "14.0.4",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -29,6 +29,9 @@ dependencies:
   '@tanstack/react-query':
     specifier: ^5.17.12
     version: 5.17.12(react@18.2.0)
+  amazon-cognito-identity-js:
+    specifier: ^6.3.7
+    version: 6.3.7
   axios:
     specifier: ^1.6.5
     version: 1.6.5
@@ -120,6 +123,36 @@ packages:
     dependencies:
       '@jridgewell/gen-mapping': 0.3.3
       '@jridgewell/trace-mapping': 0.3.22
+
+  /@aws-crypto/sha256-js@1.2.2:
+    resolution: {integrity: sha512-Nr1QJIbW/afYYGzYvrF70LtaHrIRtd4TNAglX8BvlfxJLZ45SAmueIKYl5tWoNBPzp65ymXGFK0Bb1vZUpuc9g==}
+    dependencies:
+      '@aws-crypto/util': 1.2.2
+      '@aws-sdk/types': 3.511.0
+      tslib: 1.14.1
+    dev: false
+
+  /@aws-crypto/util@1.2.2:
+    resolution: {integrity: sha512-H8PjG5WJ4wz0UXAFXeJjWCW1vkvIJ3qUUD+rGRwJ2/hj+xT58Qle2MTql/2MGzkU+1JLAFuR6aJpLAjHwhmwwg==}
+    dependencies:
+      '@aws-sdk/types': 3.511.0
+      '@aws-sdk/util-utf8-browser': 3.259.0
+      tslib: 1.14.1
+    dev: false
+
+  /@aws-sdk/types@3.511.0:
+    resolution: {integrity: sha512-P03ufufxmkvd7nO46oOeEqYIMPJ8qMCKxAsfJk1JBVPQ1XctVntbail4/UFnrnzij8DTl4Mk/D62uGo7+RolXA==}
+    engines: {node: '>=14.0.0'}
+    dependencies:
+      '@smithy/types': 2.9.1
+      tslib: 2.6.2
+    dev: false
+
+  /@aws-sdk/util-utf8-browser@3.259.0:
+    resolution: {integrity: sha512-UvFa/vR+e19XookZF8RzFZBrw2EUkQWxiBW0yYQAhvk3C+QVGl0H3ouca8LDBlBfQKXwmW3huo/59H8rwb1wJw==}
+    dependencies:
+      tslib: 2.6.2
+    dev: false
 
   /@babel/code-frame@7.23.5:
     resolution: {integrity: sha512-CgH3s1a96LipHCmSUmYFPwY7MNx8C3avkq7i4Wl3cfa662ldtUe4VM1TPXX70pfmrlWTb6jLqTYrZyT2ZTJBgA==}
@@ -3066,6 +3099,13 @@ packages:
     resolution: {integrity: sha512-UY+FGM/2jjMkzQLn8pxcHGMaVLh9aEitG3zY2CiY7XHdLiz3bZOwa6oDxNqEMv7zZkV+cj5DOdz0cQ1BP5Hjgw==}
     dev: true
 
+  /@smithy/types@2.9.1:
+    resolution: {integrity: sha512-vjXlKNXyprDYDuJ7UW5iobdmyDm6g8dDG+BFUncAg/3XJaN45Gy5RWWWUVgrzIK7S4R1KWgIX5LeJcfvSI24bw==}
+    engines: {node: '>=14.0.0'}
+    dependencies:
+      tslib: 2.6.2
+    dev: false
+
   /@svgr/babel-plugin-add-jsx-attribute@8.0.0(@babel/core@7.23.7):
     resolution: {integrity: sha512-b9MIk7yhdS1pMCZM8VeNfUlSKVRhsHZNMl5O9SfaX0l0t5wjdgu4IDzGB8bpnGBBOjGST3rRFVsaaEtI4W6f7g==}
     engines: {node: '>=14'}
@@ -3433,6 +3473,18 @@ packages:
       uri-js: 4.4.1
     dev: true
 
+  /amazon-cognito-identity-js@6.3.7:
+    resolution: {integrity: sha512-tSjnM7KyAeOZ7UMah+oOZ6cW4Gf64FFcc7BE2l7MTcp7ekAPrXaCbpcW2xEpH1EiDS4cPcAouHzmCuc2tr72vQ==}
+    dependencies:
+      '@aws-crypto/sha256-js': 1.2.2
+      buffer: 4.9.2
+      fast-base64-decode: 1.0.0
+      isomorphic-unfetch: 3.1.0
+      js-cookie: 2.2.1
+    transitivePeerDependencies:
+      - encoding
+    dev: false
+
   /ansi-escapes@6.2.0:
     resolution: {integrity: sha512-kzRaCqXnpzWs+3z5ABPQiVke+iq0KXkHo8xiWV4RPTi5Yli0l97BEQuhXV1s7+aSU/fu1kUuxgS4MsQ0fRuygw==}
     engines: {node: '>=14.16'}
@@ -3669,6 +3721,10 @@ packages:
     resolution: {integrity: sha512-1ugUSr8BHXRnK23KfuYS+gVMC3LB8QGH9W1iGtDPsNWoQbgtXSExkBu2aDR4epiGWZOjZsj6lDl/N/AqqTC3UA==}
     dev: true
 
+  /base64-js@1.5.1:
+    resolution: {integrity: sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==}
+    dev: false
+
   /boolbase@1.0.0:
     resolution: {integrity: sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==}
     dev: true
@@ -3702,6 +3758,14 @@ packages:
       electron-to-chromium: 1.4.645
       node-releases: 2.0.14
       update-browserslist-db: 1.0.13(browserslist@4.22.2)
+
+  /buffer@4.9.2:
+    resolution: {integrity: sha512-xq+q3SRMOxGivLhBNaUdC64hDTQwejJ+H0T/NB1XMtTVEwNTrfFF3gAxiyW0Bu/xWEGhjVKgUcMhCrUy2+uCWg==}
+    dependencies:
+      base64-js: 1.5.1
+      ieee754: 1.2.1
+      isarray: 1.0.0
+    dev: false
 
   /busboy@1.6.0:
     resolution: {integrity: sha512-8SFQbg/0hQ9xy3UNTB0YEnsNBbWfhf7RtnzpL7TkBiTBRfrQ9Fxcnz7VJsleJpyp6rVLvXiuORqjlHi5q+PYuA==}
@@ -4631,6 +4695,10 @@ packages:
       strip-final-newline: 3.0.0
     dev: true
 
+  /fast-base64-decode@1.0.0:
+    resolution: {integrity: sha512-qwaScUgUGBYeDNRnbc/KyllVU88Jk1pRHPStuF/lO7B0/RTRLj7U0lkdTAutlBblY08rwZDff6tNU9cjv6j//Q==}
+    dev: false
+
   /fast-deep-equal@3.1.3:
     resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
     dev: true
@@ -5084,6 +5152,10 @@ packages:
     hasBin: true
     dev: true
 
+  /ieee754@1.2.1:
+    resolution: {integrity: sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==}
+    dev: false
+
   /ignore@5.3.0:
     resolution: {integrity: sha512-g7dmpshy+gD7mh88OC9NwSGTKoc3kyLAZQRU1mt53Aw/vnvfXnbC+F/7F7QoYVKbV+KNvJx8wArewKy1vXMtlg==}
     engines: {node: '>= 4'}
@@ -5341,6 +5413,10 @@ packages:
       get-intrinsic: 1.2.2
     dev: true
 
+  /isarray@1.0.0:
+    resolution: {integrity: sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==}
+    dev: false
+
   /isarray@2.0.5:
     resolution: {integrity: sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==}
     dev: true
@@ -5348,6 +5424,15 @@ packages:
   /isexe@2.0.0:
     resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
     dev: true
+
+  /isomorphic-unfetch@3.1.0:
+    resolution: {integrity: sha512-geDJjpoZ8N0kWexiwkX8F9NkTsXhetLPVbZFQ+JTW239QNOwvB0gniuR1Wc6f0AMTn7/mFGyXvHTifrCp/GH8Q==}
+    dependencies:
+      node-fetch: 2.7.0
+      unfetch: 4.2.0
+    transitivePeerDependencies:
+      - encoding
+    dev: false
 
   /iterator.prototype@1.1.2:
     resolution: {integrity: sha512-DR33HMMr8EzwuRL8Y9D3u2BMj8+RqSE850jfGu59kS7tbmPLzGkZmVSfyCFSDxuZiEY6Rzt3T2NA/qU+NwVj1w==}
@@ -5372,6 +5457,10 @@ packages:
     resolution: {integrity: sha512-gFqAIbuKyyso/3G2qhiO2OM6shY6EPP/R0+mkDbyspxKazh8BXDC5FiFsUjlczgdNz/vfra0da2y+aHrusLG/Q==}
     hasBin: true
     dev: true
+
+  /js-cookie@2.2.1:
+    resolution: {integrity: sha512-HvdH2LzI/EAZcUwA8+0nKNtWHqS+ZmijLA30RwZA0bo7ToCckjK5MkGhjED9KoRcXO6BaGI3I9UIzSA1FKFPOQ==}
+    dev: false
 
   /js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
@@ -5803,6 +5892,18 @@ packages:
       lower-case: 2.0.2
       tslib: 2.6.2
     dev: true
+
+  /node-fetch@2.7.0:
+    resolution: {integrity: sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==}
+    engines: {node: 4.x || >=6.0.0}
+    peerDependencies:
+      encoding: ^0.1.0
+    peerDependenciesMeta:
+      encoding:
+        optional: true
+    dependencies:
+      whatwg-url: 5.0.0
+    dev: false
 
   /node-releases@2.0.14:
     resolution: {integrity: sha512-y10wOWt8yZpqXmOgRo77WaHEmhYQYGNA6y421PKsKYWEK8aW+cqAphborZDhqfyKrbZEN92CN1X2KbafY2s7Yw==}
@@ -6942,6 +7043,10 @@ packages:
     resolution: {integrity: sha512-BiZS+C1OS8g/q2RRbJmy59xpyghNBqrr6k5L/uKBGRsTfxmu3ffiRnd8mlGPUVayg8pvfi5urfnu8TU7DVOkLQ==}
     dev: false
 
+  /tr46@0.0.3:
+    resolution: {integrity: sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==}
+    dev: false
+
   /trim-newlines@3.0.1:
     resolution: {integrity: sha512-c1PTsA3tYrIsLGkJkzHF+w9F2EyxfXGo4UyJc4pFL++FMjnq0HJS69T3M7d//gKrFKwy429bouPescbjecU+Zw==}
     engines: {node: '>=8'}
@@ -6964,6 +7069,10 @@ packages:
       minimist: 1.2.8
       strip-bom: 3.0.0
     dev: true
+
+  /tslib@1.14.1:
+    resolution: {integrity: sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==}
+    dev: false
 
   /tslib@2.4.0:
     resolution: {integrity: sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==}
@@ -7061,6 +7170,10 @@ packages:
     resolution: {integrity: sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==}
     dev: true
 
+  /unfetch@4.2.0:
+    resolution: {integrity: sha512-F9p7yYCn6cIW9El1zi0HI6vqpeIvBsr3dSuRO6Xuppb1u5rXpCPmMvLSyECLhybr9isec8Ohl0hPekMVrEinDA==}
+    dev: false
+
   /unicode-canonical-property-names-ecmascript@2.0.0:
     resolution: {integrity: sha512-yY5PpDlfVIU5+y/BSCxAJRBIS1Zc2dDG3Ujq+sR0U+JjUevW2JhocOF+soROYDSaAezOzOKuyyixhD6mBknSmQ==}
     engines: {node: '>=4'}
@@ -7148,6 +7261,17 @@ packages:
     dependencies:
       glob-to-regexp: 0.4.1
       graceful-fs: 4.2.11
+    dev: false
+
+  /webidl-conversions@3.0.1:
+    resolution: {integrity: sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==}
+    dev: false
+
+  /whatwg-url@5.0.0:
+    resolution: {integrity: sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==}
+    dependencies:
+      tr46: 0.0.3
+      webidl-conversions: 3.0.1
     dev: false
 
   /which-boxed-primitive@1.0.2:

--- a/src/components/pages/login/login-form.tsx
+++ b/src/components/pages/login/login-form.tsx
@@ -55,12 +55,12 @@ export function LoginForm() {
         console.log('accessToken', accessToken);
       },
       onFailure: function (err) {
-        if (err.message == 'User is not confirmed.') {
+        if (err.code === USER_NOT_CONFIRMED_EXCEPTION) {
           setError('root.serverError', {
             type: USER_NOT_CONFIRMED_EXCEPTION,
             message: '가입한 이메일을 인증해주세요.',
           });
-        } else if (err.message == 'Incorrect username or password.') {
+        } else if (err.code === NOT_AUTHORIZED_EXCEPTION) {
           setError('root.serverError', {
             type: NOT_AUTHORIZED_EXCEPTION,
             message: '이메일 또는 비밀번호가 잘못되었습니다.',

--- a/src/components/pages/login/types.ts
+++ b/src/components/pages/login/types.ts
@@ -1,0 +1,4 @@
+export interface LoginFormValues {
+  email: string;
+  password: string;
+}

--- a/src/components/pages/sign-up/sign-up-form.tsx
+++ b/src/components/pages/sign-up/sign-up-form.tsx
@@ -1,3 +1,4 @@
+import { useRouter } from 'next/router';
 import { Controller, useForm } from 'react-hook-form';
 import {
   VStack,
@@ -10,9 +11,12 @@ import {
 } from '@chakra-ui/react';
 import PasswordInput from '@/components/common/input/password-input';
 import { Form } from './styles';
-import { FormValues } from './types';
+import { SignUpFormValues } from './types';
+import userPool from '@/lib/user-pool';
 
 export default function SignUpForm() {
+  const router = useRouter();
+
   const defaultValues = {
     email: '',
     newPassword: '',
@@ -25,14 +29,20 @@ export default function SignUpForm() {
     register,
     formState: { errors },
     getValues,
-  } = useForm<FormValues>({ defaultValues });
+  } = useForm<SignUpFormValues>({ defaultValues });
 
-  function onSubmit(values: FormValues) {
-    console.log('submit', values);
+  function handleSignUp({ email, newPassword }: SignUpFormValues) {
+    userPool.signUp(email, newPassword, [], [], (error, data) => {
+      if (error) {
+        return console.error(error);
+      }
+      alert('회원가입 완료! 이메일을 확인하여 인증 바랍니다.');
+      router.push('/login');
+    });
   }
 
   return (
-    <Form onSubmit={handleSubmit(onSubmit)}>
+    <Form onSubmit={handleSubmit(handleSignUp)}>
       <VStack w="100%" spacing="24px">
         <FormControl isInvalid={!!errors.email}>
           <HStack marginBottom="12px">
@@ -87,6 +97,10 @@ export default function SignUpForm() {
             )}
           />
         </FormControl>
+        <VStack width="full" alignItems="flex-start" gap={0}>
+          <p>* 비밀번호는 8~16자 이내로 입력해주세요.</p>
+          <p>* 비밀번호는 영어, 숫자, 특수문자를 포함해야 합니다.</p>
+        </VStack>
         <FormControl isInvalid={!!errors.confirmPassword}>
           <HStack marginBottom="12px">
             <FormLabel htmlFor="confirmPassword" margin="0px">

--- a/src/components/pages/sign-up/sign-up-form.tsx
+++ b/src/components/pages/sign-up/sign-up-form.tsx
@@ -13,6 +13,7 @@ import PasswordInput from '@/components/common/input/password-input';
 import { Form } from './styles';
 import { SignUpFormValues } from './types';
 import userPool from '@/lib/user-pool';
+import { ROUTES } from '@/constants/routes';
 
 export default function SignUpForm() {
   const router = useRouter();
@@ -34,10 +35,11 @@ export default function SignUpForm() {
   function handleSignUp({ email, newPassword }: SignUpFormValues) {
     userPool.signUp(email, newPassword, [], [], (error, data) => {
       if (error) {
-        return console.error(error);
+        console.error(error);
+        return;
       }
       alert('회원가입 완료! 이메일을 확인하여 인증 바랍니다.');
-      router.push('/login');
+      router.push(ROUTES.LOGIN);
     });
   }
 

--- a/src/components/pages/sign-up/types.ts
+++ b/src/components/pages/sign-up/types.ts
@@ -1,4 +1,4 @@
-export interface FormValues {
+export interface SignUpFormValues {
   email: string;
   newPassword: string;
   confirmPassword: string;

--- a/src/lib/user-pool.ts
+++ b/src/lib/user-pool.ts
@@ -1,0 +1,12 @@
+import {
+  CognitoUserPool,
+  ICognitoUserPoolData,
+} from 'amazon-cognito-identity-js';
+
+const userPoolData: ICognitoUserPoolData = {
+  UserPoolId: process.env.NEXT_PUBLIC_COGNITO_USER_POOL_ID,
+  ClientId: process.env.NEXT_PUBLIC_COGNITO_CLIENT_ID,
+};
+
+const userPool = new CognitoUserPool(userPoolData);
+export default userPool;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -18,6 +18,6 @@
     },
     "types": ["@emotion/react/types/css-prop"]
   },
-  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", "global.d.ts"],
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", "global.d.ts", "env.d.ts"],
   "exclude": ["node_modules"]
 }


### PR DESCRIPTION
## 📝 작업 내용

- 회원가입과 로그인에 AWS Cognito를 적용하였습니다.
  - Cognito user pool ID와 Client app ID가 필요한데, 이는 지금 `.env.local`에 설정해놓았습니다. 공유 드릴게요!
- 로그인 시 에러 메세지는 구체적이지 않아도 좋을 것 같아, 기존 로그인 form에서 에러 메세지를 이메일과 비밀번호 각각 보여주던 것에서 전체 form 에러로 뭉뚱그려 보여지도록 변경했습니다.
- 지금은 이메일과 비밀번호를 통한 사용자 인증만 가능합니다. OAuth2.0을 통한 구글 소셜 로그인 기능은 추가해야 합니다.

## 📚 참고

- [블로그 썼습니다!](https://velog.io/@dkkim0122/AWS-Cognito%EB%A5%BC-%EC%82%AC%EC%9A%A9%ED%95%98%EC%97%AC-%EB%A1%9C%EA%B7%B8%EC%9D%B8%EA%B3%BC-%ED%9A%8C%EC%9B%90%EA%B0%80%EC%9E%85-%EA%B5%AC%ED%98%84%ED%95%98%EA%B8%B0)

## ❤️ 리뷰 요구사항

- 회원가입 시 입력한 이메일 주소로 인증 이메일이 보내집니다. 사용자가 이메일을 확인해야 인증이 완료되고 회원가입도 끝나게 되는데, 지금 그에 대한 UX가 부족한 것 같아요.
- 지금 적용해 놓은 Cognito 사용자 풀은 테스트(개발)용으로 만들어 놨고, 배포 시에 필요한 실제 사용자 풀은 만들어야 할 것 같습니다.
  - 보통 배포 관련해서 환경변수 설정은 어떻게 하시나요?? 찾아보니 vercel에 직접 설정하는 방법도 있고 .env 파일을 따로 만들어서 하기도 하더라구요
- login-form 컴포넌트에서 로그인 시 엑세스 token을 받을 수 있습니다. 이를 이제 API랑 연결하고 HTTP Authorization 헤더에 Bearer token으로 연결하면 될 거 같습니다! 어떤 API 라이브러리를 사용할지도 논의해봐야 할 것 같습니다.
